### PR TITLE
Update copyright generation to work with T1 fontencoding

### DIFF
--- a/ucetd.cls
+++ b/ucetd.cls
@@ -21,7 +21,7 @@
 % Default copyright text
 \newcommand{\etdCopyrightText}{
 	\null\vfill
-	\centerline{Copyright \copyright\ \number\year\ by \@author}
+	\centerline{Copyright \textcopyright\ \number\year\ by \@author}
 	\centerline{All Rights Reserved}
 	\vskip 15pt\relax
 }


### PR DESCRIPTION
`\copyright` is not defined in T1 but `\textcopyright`is

Sources:
https://github.com/harveymuddcollege/hmcthesis-class/commit/49495c7cf37aecb4b7b6a4a9e971306c66ee9b4a 
https://tex.stackexchange.com/questions/29895/how-to-get-copyright-when-mixing-t1-fonts-and-fontspec